### PR TITLE
Use quay.io and update default docker tag

### DIFF
--- a/doc/grafana_prometheus.md
+++ b/doc/grafana_prometheus.md
@@ -320,4 +320,5 @@ to product even more metrics that can then be consumed and rendered in Grafana.
 | ---------------------------------------- | ------------------- | ------------------ |
 | 1.0                                      | 4.4.2               | CentOS 7, Python 2 |
 | 2.0                                      | 4.4.2               | Python 3           |
-| 2.1                                      | 4.6.0               | Python 3           |
+| 2.1                                      | 4.6.0+              | Python 3           |
+| 2.2 (tbd)                                | (tbd)               | (tbd)              |

--- a/prometheus/docker/docker-compose.yml
+++ b/prometheus/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 services:
   data-bridge:
-    image: univa/unisight-data-bridge:2.1
+    image: quay.io/univa/unisight-data-bridge:latest
     container_name: data-bridge
     environment:
       - UNISIGHT_ADMIN_USER=$UNISIGHT_ADMIN_USER


### PR DESCRIPTION
    The master build will always use the 'latest' refs.  When creating
    a 'release' branch (ie v2.2) we will pin the tag to a matching
    version.